### PR TITLE
[Feat] Suggest using unmock

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
 		"Other"
 	],
 	"activationEvents": [
-		"workspaceContains:**/*.json"
+		"workspaceContains:**/*.json",
+		"onLanguage:javascript",
+		"onLanguage:typescript"
 	],
 	"main": "./out/extension.js",
 	"contributes": {

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -37,7 +37,8 @@ export class MockExplorer implements vscode.TreeDataProvider<MockTreeItem> {
                     const hash = path.basename(path.dirname(fileUri.fsPath));
                     axios.post(`https://api.unmock.io:443/mocks/${hash}`, { response: JSON.stringify(fileContents) },
                         { headers: { Authorization: `Bearer ${accessToken}`}},
-                    );
+                    ).then((res) => vscode.commands.executeCommand("unmock.statusbar.text", "Sync'd with unmock cloud!"))
+                     .catch((reason) => vscode.commands.executeCommand("unmock.statusbar.text", `Unable to sync with unmock cloud - ${reason}`));
                 }
             });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,8 +4,15 @@ import * as path from "path";
 import * as ini from "ini";
 import * as os from "os";
 import { MockExplorer, MockTreeItem } from "./explorer";
+import { JestTestFileSelector, TypescriptGotoMockProvider } from "./providers";
 
 export function activate(context: vscode.ExtensionContext) {
+	// Add the suggestion CodeLens
+	vscode.commands.registerTextEditorCommand("unmock.insertUnmockToTest",
+		(textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]) => {
+			textEditor.insertSnippet(new vscode.SnippetString("import { unmock } from \"unmock\";"), new vscode.Position(0, 0));
+	});
+	vscode.languages.registerCodeLensProvider(JestTestFileSelector, new TypescriptGotoMockProvider());
 
 	// Add the extension button
 	const jsonExplorer = new MockExplorer();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,8 @@ import * as ini from "ini";
 import * as os from "os";
 import { IInsertUnmockAction } from "./interfaces";
 import { MockExplorer, MockTreeItem } from "./explorer";
-import { JestTestFileSelector, TypescriptInsertUnmockCodeLens, TypeScriptInsertUnmockAction } from "./providers";
+import { AllJSFileFilters, TypescriptInsertUnmockCodeLens, TypeScriptInsertUnmockAction } from "./providers";
+import { getImportStatement, getTestCalls } from "./utils";
 
 export function activate(context: vscode.ExtensionContext) {
 	// Add the suggestion CodeLens
@@ -15,17 +16,16 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 			const argsObj = args[0];
-			textEditor.insertSnippet(new vscode.SnippetString("import { unmock, kcomnu } from \"unmock\";\n"),
+			textEditor.insertSnippet(new vscode.SnippetString(`${getImportStatement(argsObj.lang)}\n`),
 									 argsObj.unmockImportLocation);
 			const lastImportLocation = argsObj.lastImportLocation;
 			// +1 to add after the last import statement, +1 to account for the addition of the unmock import
 			const afterLastImport = new vscode.Range(lastImportLocation.line + 2, 0, lastImportLocation.line + 2, 0);
-			textEditor.insertSnippet(new vscode.SnippetString("\nbeforeEach(async () => await unmock());\n" +
-																"afterEach(() => kcomnu());\n"), afterLastImport);
+			textEditor.insertSnippet(new vscode.SnippetString(`\n${getTestCalls(argsObj.lang)}\n`), afterLastImport);
 	});
-	vscode.languages.registerCodeLensProvider(JestTestFileSelector, new TypescriptInsertUnmockCodeLens());
+	vscode.languages.registerCodeLensProvider(AllJSFileFilters, new TypescriptInsertUnmockCodeLens());
 	// Registers lightbulb
-	vscode.languages.registerCodeActionsProvider(JestTestFileSelector, new TypeScriptInsertUnmockAction());
+	vscode.languages.registerCodeActionsProvider(AllJSFileFilters, new TypeScriptInsertUnmockAction());
 
 	// Add the extension button
 	const jsonExplorer = new MockExplorer();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,8 @@ import * as ini from "ini";
 import * as os from "os";
 import { IInsertUnmockAction } from "./interfaces";
 import { MockExplorer, MockTreeItem } from "./explorer";
-import { AllJSFileFilters, TypescriptInsertUnmockCodeLens, TypeScriptInsertUnmockAction } from "./providers";
+import { AllJSFileFilters, TypescriptInsertUnmockCodeLens, TypeScriptInsertUnmockAction,
+		 InsertUnmockHoverProvider } from "./providers";
 import { getImportStatement, getTestCalls } from "./utils";
 
 export function activate(context: vscode.ExtensionContext) {
@@ -23,6 +24,7 @@ export function activate(context: vscode.ExtensionContext) {
 			const afterLastImport = new vscode.Range(lastImportLocation.line + 2, 0, lastImportLocation.line + 2, 0);
 			textEditor.insertSnippet(new vscode.SnippetString(`\n${getTestCalls(argsObj.lang)}\n`), afterLastImport);
 	});
+	vscode.languages.registerHoverProvider(AllJSFileFilters, new InsertUnmockHoverProvider());
 	vscode.languages.registerCodeLensProvider(AllJSFileFilters, new TypescriptInsertUnmockCodeLens());
 	// Registers lightbulb
 	vscode.languages.registerCodeActionsProvider(AllJSFileFilters, new TypeScriptInsertUnmockAction());

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,13 +12,22 @@ export function activate(context: vscode.ExtensionContext) {
 		(textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]) => {
 			textEditor.insertSnippet(new vscode.SnippetString("import { unmock, kcomnu } from \"unmock\";\n"), new vscode.Position(0, 0));
 			if (args.length > 0) {
-				const pos: vscode.Range = args[0];
-				const lineBefore = new vscode.Range(pos.start.line + 1, pos.start.character, pos.start.line + 1, pos.start.character);
-				const endOfLine = new vscode.Range(pos.start.line + 2, pos.end.character, pos.start.line + 2, pos.end.character);
-				const lineAfter = new vscode.Range(pos.end.line + 3, pos.start.character, pos.end.line + 3, pos.start.character);
-				textEditor.insertSnippet(new vscode.SnippetString("unmock();\n"), lineBefore); // Insert line before
-				textEditor.insertSnippet(new vscode.SnippetString("\n"), endOfLine);
-				textEditor.insertSnippet(new vscode.SnippetString("kcomnu();"), lineAfter);
+				// TODO: Define an interface for this?
+				const argsObj = args[0];
+				// Code to surround a single call with unmock and kcomnu
+				// const pos: vscode.Range = argsObj.relevantRange;
+				// const lineBefore = new vscode.Range(pos.start.line + 1, pos.start.character, pos.start.line + 1, pos.start.character);
+				// const endOfLine = new vscode.Range(pos.start.line + 2, pos.end.character, pos.start.line + 2, pos.end.character);
+				// const lineAfter = new vscode.Range(pos.end.line + 3, pos.start.character, pos.end.line + 3, pos.start.character);
+				// textEditor.insertSnippet(new vscode.SnippetString("unmock();\n"), lineBefore); // Insert line before
+				// textEditor.insertSnippet(new vscode.SnippetString("\n"), endOfLine);
+				// textEditor.insertSnippet(new vscode.SnippetString("kcomnu();"), lineAfter);
+				
+				const lastImportLocation: vscode.Position = argsObj.lastImportLocation;
+				// +1 to add after the last import statement, +1 to account for the addition of the unmock import
+				const afterLastImport = new vscode.Range(lastImportLocation.line + 2, 0, lastImportLocation.line + 2, 0);
+				textEditor.insertSnippet(new vscode.SnippetString("\nbeforeEach(async () => await unmock());\n" +
+																  "afterEach(() => kcomnu());\n"), afterLastImport);
 			}
 	});
 	vscode.languages.registerCodeLensProvider(JestTestFileSelector, new TypescriptInsertUnmockCodeLens());

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,15 +4,26 @@ import * as path from "path";
 import * as ini from "ini";
 import * as os from "os";
 import { MockExplorer, MockTreeItem } from "./explorer";
-import { JestTestFileSelector, TypescriptGotoMockProvider } from "./providers";
+import { JestTestFileSelector, TypescriptInsertUnmockCodeLens, TypeScriptInsertUnmockAction } from "./providers";
 
 export function activate(context: vscode.ExtensionContext) {
 	// Add the suggestion CodeLens
 	vscode.commands.registerTextEditorCommand("unmock.insertUnmockToTest",
 		(textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]) => {
-			textEditor.insertSnippet(new vscode.SnippetString("import { unmock } from \"unmock\";"), new vscode.Position(0, 0));
+			textEditor.insertSnippet(new vscode.SnippetString("import { unmock, kcomnu } from \"unmock\";\n"), new vscode.Position(0, 0));
+			if (args.length > 0) {
+				const pos: vscode.Range = args[0];
+				const lineBefore = new vscode.Range(pos.start.line + 1, pos.start.character, pos.start.line + 1, pos.start.character);
+				const endOfLine = new vscode.Range(pos.start.line + 2, pos.end.character, pos.start.line + 2, pos.end.character);
+				const lineAfter = new vscode.Range(pos.end.line + 3, pos.start.character, pos.end.line + 3, pos.start.character);
+				textEditor.insertSnippet(new vscode.SnippetString("unmock();\n"), lineBefore); // Insert line before
+				textEditor.insertSnippet(new vscode.SnippetString("\n"), endOfLine);
+				textEditor.insertSnippet(new vscode.SnippetString("kcomnu();"), lineAfter);
+			}
 	});
-	vscode.languages.registerCodeLensProvider(JestTestFileSelector, new TypescriptGotoMockProvider());
+	vscode.languages.registerCodeLensProvider(JestTestFileSelector, new TypescriptInsertUnmockCodeLens());
+	// Registers lightbulb
+	vscode.languages.registerCodeActionsProvider(JestTestFileSelector, new TypeScriptInsertUnmockAction());
 
 	// Add the extension button
 	const jsonExplorer = new MockExplorer();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,14 +15,13 @@ export function activate(context: vscode.ExtensionContext) {
 				return;
 			}
 			const argsObj = args[0];
-			textEditor.insertSnippet(new vscode.SnippetString("import { unmock, kcomnu } from \"unmock\";\n"), new vscode.Position(0, 0));
-			if (args.length > 0) {
-				const lastImportLocation = argsObj.lastImportLocation;
-				// +1 to add after the last import statement, +1 to account for the addition of the unmock import
-				const afterLastImport = new vscode.Range(lastImportLocation.line + 2, 0, lastImportLocation.line + 2, 0);
-				textEditor.insertSnippet(new vscode.SnippetString("\nbeforeEach(async () => await unmock());\n" +
-																  "afterEach(() => kcomnu());\n"), afterLastImport);
-			}
+			textEditor.insertSnippet(new vscode.SnippetString("import { unmock, kcomnu } from \"unmock\";\n"),
+									 argsObj.unmockImportLocation);
+			const lastImportLocation = argsObj.lastImportLocation;
+			// +1 to add after the last import statement, +1 to account for the addition of the unmock import
+			const afterLastImport = new vscode.Range(lastImportLocation.line + 2, 0, lastImportLocation.line + 2, 0);
+			textEditor.insertSnippet(new vscode.SnippetString("\nbeforeEach(async () => await unmock());\n" +
+																"afterEach(() => kcomnu());\n"), afterLastImport);
 	});
 	vscode.languages.registerCodeLensProvider(JestTestFileSelector, new TypescriptInsertUnmockCodeLens());
 	// Registers lightbulb

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,27 +3,21 @@ import * as fs from "fs";
 import * as path from "path";
 import * as ini from "ini";
 import * as os from "os";
+import { IInsertUnmockAction } from "./interfaces";
 import { MockExplorer, MockTreeItem } from "./explorer";
 import { JestTestFileSelector, TypescriptInsertUnmockCodeLens, TypeScriptInsertUnmockAction } from "./providers";
 
 export function activate(context: vscode.ExtensionContext) {
 	// Add the suggestion CodeLens
 	vscode.commands.registerTextEditorCommand("unmock.insertUnmockToTest",
-		(textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: any[]) => {
+		(textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, ...args: IInsertUnmockAction[]) => {
+			if (args.length === 0) {
+				return;
+			}
+			const argsObj = args[0];
 			textEditor.insertSnippet(new vscode.SnippetString("import { unmock, kcomnu } from \"unmock\";\n"), new vscode.Position(0, 0));
 			if (args.length > 0) {
-				// TODO: Define an interface for this?
-				const argsObj = args[0];
-				// Code to surround a single call with unmock and kcomnu
-				// const pos: vscode.Range = argsObj.relevantRange;
-				// const lineBefore = new vscode.Range(pos.start.line + 1, pos.start.character, pos.start.line + 1, pos.start.character);
-				// const endOfLine = new vscode.Range(pos.start.line + 2, pos.end.character, pos.start.line + 2, pos.end.character);
-				// const lineAfter = new vscode.Range(pos.end.line + 3, pos.start.character, pos.end.line + 3, pos.start.character);
-				// textEditor.insertSnippet(new vscode.SnippetString("unmock();\n"), lineBefore); // Insert line before
-				// textEditor.insertSnippet(new vscode.SnippetString("\n"), endOfLine);
-				// textEditor.insertSnippet(new vscode.SnippetString("kcomnu();"), lineAfter);
-				
-				const lastImportLocation: vscode.Position = argsObj.lastImportLocation;
+				const lastImportLocation = argsObj.lastImportLocation;
 				// +1 to add after the last import statement, +1 to account for the addition of the unmock import
 				const afterLastImport = new vscode.Range(lastImportLocation.line + 2, 0, lastImportLocation.line + 2, 0);
 				textEditor.insertSnippet(new vscode.SnippetString("\nbeforeEach(async () => await unmock());\n" +

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,11 +7,21 @@ import { MockExplorer, MockTreeItem } from "./explorer";
 
 export function activate(context: vscode.ExtensionContext) {
 
+	// Add the extension button
 	const jsonExplorer = new MockExplorer();
 	vscode.window.registerTreeDataProvider("unmock.mocksExplorer", jsonExplorer);
 	vscode.commands.registerCommand("unmock.editMock", (element: MockTreeItem) => {
 		vscode.commands.executeCommand("vscode.open", vscode.Uri.file(element.currentPath));
 	});
+
+	// Create the statusbar section
+	const statusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+	vscode.commands.registerCommand("unmock.statusbar.hide", () => statusBar.hide());
+	vscode.commands.registerCommand("unmock.statusbar.text", (text: string) => {
+		statusBar.text = `Unmock: ${text}`;
+		statusBar.show();
+	});
+	statusBar.command = "unmock.statusbar.hide";
 
 	const config = vscode.workspace.getConfiguration("unmock");
 	let refreshToken: string | undefined = config.refreshToken;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,5 +2,5 @@ import * as vscode from "vscode";
 
 export interface IInsertUnmockAction {
     lastImportLocation: vscode.Position;
-    addImport?: boolean;
+    unmockImportLocation: vscode.Range;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,0 +1,6 @@
+import * as vscode from "vscode";
+
+export interface IInsertUnmockAction {
+    lastImportLocation: vscode.Position;
+    addImport?: boolean;
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -3,4 +3,5 @@ import * as vscode from "vscode";
 export interface IInsertUnmockAction {
     lastImportLocation: vscode.Position;
     unmockImportLocation: vscode.Range;
+    lang: string;
 }

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,0 +1,13 @@
+import * as vscode from "vscode";
+
+export const JestTestFileSelector: vscode.DocumentSelector = {};
+
+export class TypescriptGotoMockProvider implements vscode.CodeLensProvider {
+    onDidChangeCodeLenses?: vscode.Event<void> | undefined;
+    provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens[]> {
+        throw new Error("Method not implemented.");
+    }
+    resolveCodeLens(codeLens: vscode.CodeLens, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens> {
+        throw new Error("Method not implemented.");
+    }
+}

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,11 +1,38 @@
 import * as vscode from "vscode";
 
-export const JestTestFileSelector: vscode.DocumentSelector = {};
+// Effectively a DocumentFilter, selecting files with ".test." in them, as is the convention in Jest
+export const JestTestFileSelector: vscode.DocumentSelector = {scheme: "file", pattern: "**/*.test.*"};
 
 export class TypescriptGotoMockProvider implements vscode.CodeLensProvider {
     onDidChangeCodeLenses?: vscode.Event<void> | undefined;
     provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens[]> {
-        throw new Error("Method not implemented.");
+        const srcText = document.getText();
+        // Remove comments (see https://gist.github.com/DesignByOnyx/05c2241affc9dc498379e0d819c4d756)
+        const srcTextWithoutComments = srcText.replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, "");
+        // Really rough sketch - look for the following as method calls
+        if (/[\w_]+\.(?:request|get|delete|head|options|post|put|patch)\(/.test(srcTextWithoutComments) &&
+            /axios|superagent|request|fetch|supertest/.test(srcTextWithoutComments) &&  // And one of these libraries has to be used
+            !/unmock\(/.test(srcTextWithoutComments)) {  // And there was no call to Unmock
+                // get line number and position -- this is unneeded if we want to show it next to the calling code
+                const matchCall = srcText.match(/[\w_]+\.(?:request|get|delete|head|options|post|put|patch)\(/);
+                if (!matchCall) {
+                    return;  // Shouldn't reach here, as we found the pattern in the text without comments...
+                }
+                let lineNumber = srcText.substr(0, matchCall.index).split("\n").length;
+                lineNumber = lineNumber > 0 ? lineNumber - 1 : lineNumber;  // Show it above where needed if possible
+                const lineLength = srcText.split("\n")[lineNumber].length;
+                // Do we want to show it at the top or around the calling code?
+                // const firstInDocument = new vscode.Position(0, 0); // Place to suggest the fix
+                const suggestionRange = new vscode.Range(lineNumber, 0, lineNumber, lineLength);
+                return [
+                    new vscode.CodeLens(suggestionRange, {
+                        command: "unmock.insertUnmockToTest",
+                        title: "Insert call to unmock",
+                        tooltip: "This test file might make actual calls to remote endpoints. You can use unmock to intercept these and get semantically correct responses instead!",
+                    })
+                ];
+        }
+        return;
     }
     resolveCodeLens(codeLens: vscode.CodeLens, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens> {
         throw new Error("Method not implemented.");

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,8 +1,13 @@
 import * as vscode from "vscode";
+import { print } from "util";
+
+const removeCommentsFromSourceText = (srcText: string) => {
+    return srcText.replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, "");
+};
 
 const matchRequestWithoutUnmock = (srcText: string) => {
     // Remove comments (see https://gist.github.com/DesignByOnyx/05c2241affc9dc498379e0d819c4d756)
-    const srcTextWithoutComments = srcText.replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, "");
+    const srcTextWithoutComments = removeCommentsFromSourceText(srcText);
     // Really rough sketch - look for the following as method calls
     if (/[\w_]+\.(?:request|get|delete|head|options|post|put|patch)\(/.test(srcTextWithoutComments) &&
         /axios|superagent|request|fetch|supertest/.test(srcTextWithoutComments) &&  // And one of these libraries has to be used
@@ -13,11 +18,31 @@ const matchRequestWithoutUnmock = (srcText: string) => {
 };
 
 const getRangeFromTextAndMatch = (srcText: string, matchCall: RegExpMatchArray) => {
-    let lineNumber = srcText.substr(0, matchCall.index).split("\n").length - 1;  // -1 for zero-based
+    const lineNumber = srcText.substr(0, matchCall.index).split("\n").length - 1;  // -1 for zero-based
     const relevantLine = srcText.split("\n")[lineNumber];
     const lineLength = relevantLine.length;
     const firstCharInLine = relevantLine.length - relevantLine.trimLeft().length;
     return new vscode.Range(lineNumber, firstCharInLine, lineNumber, lineLength);
+};
+
+const findLastImport = (srcText: string) => {
+    const defaultPosition = new vscode.Position(0, 0);
+    // Get last "import" in commentless code
+    const srcTextWithoutComments = removeCommentsFromSourceText(srcText);
+    // Match for ^import
+    const match = srcTextWithoutComments.match(/^import [^;]+;/gm);
+    if (match === null) {
+        // return default answer?
+        return defaultPosition;
+    }
+    const lastMatch = match.pop();
+    if (lastMatch === undefined) {
+        // return default answer?
+        return defaultPosition;
+    }
+    // find location of lastMatch...
+    const flatIndexOf = srcText.lastIndexOf(lastMatch);
+    return new vscode.Position(srcText.substr(0, flatIndexOf).split("\n").length - 1, 0);
 };
 
 // Effectively a DocumentFilter, selecting files with ".test." in them, as is the convention in Jest
@@ -39,7 +64,11 @@ export class TypeScriptInsertUnmockAction implements vscode.CodeActionProvider {
         }
 
         const action = new vscode.CodeAction("Insert call to unmock", vscode.CodeActionKind.QuickFix);
-        action.command = {command: "unmock.insertUnmockToTest", title: "Insert call to unmock", arguments: [relevantRange]};
+        action.command = {
+            command: "unmock.insertUnmockToTest",
+            title: "Insert call to unmock",
+            arguments: [{lastImportLocation: findLastImport(srcText), relevantRange}]
+        };
         action.diagnostics = [
             new vscode.Diagnostic(relevantRange,
                                     `This test file might make real calls to remote endpoints.\n
@@ -55,6 +84,7 @@ export class TypescriptInsertUnmockCodeLens implements vscode.CodeLensProvider {
     provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens[]> {
         const srcText = document.getText();
         const matchCall = matchRequestWithoutUnmock(srcText);
+        findLastImport(srcText);
         if (!matchCall) {
             return;
         }
@@ -63,7 +93,7 @@ export class TypescriptInsertUnmockCodeLens implements vscode.CodeLensProvider {
             new vscode.CodeLens(relevantRange, {
                 command: "unmock.insertUnmockToTest",
                 title: "Insert call to unmock",
-                arguments: [relevantRange]
+                arguments: [{lastImportLocation: findLastImport(srcText), relevantRange}]
             })
         ];
     }

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,40 +1,70 @@
 import * as vscode from "vscode";
 
+const matchRequestWithoutUnmock = (srcText: string) => {
+    // Remove comments (see https://gist.github.com/DesignByOnyx/05c2241affc9dc498379e0d819c4d756)
+    const srcTextWithoutComments = srcText.replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, "");
+    // Really rough sketch - look for the following as method calls
+    if (/[\w_]+\.(?:request|get|delete|head|options|post|put|patch)\(/.test(srcTextWithoutComments) &&
+        /axios|superagent|request|fetch|supertest/.test(srcTextWithoutComments) &&  // And one of these libraries has to be used
+        !/unmock\(/.test(srcTextWithoutComments)) {  // And there was no call to Unmock
+            return srcText.match(/[\w_]+\.(?:request|get|delete|head|options|post|put|patch)\(/);
+    }
+    return;
+};
+
+const getRangeFromTextAndMatch = (srcText: string, matchCall: RegExpMatchArray) => {
+    let lineNumber = srcText.substr(0, matchCall.index).split("\n").length - 1;  // -1 for zero-based
+    const relevantLine = srcText.split("\n")[lineNumber];
+    const lineLength = relevantLine.length;
+    const firstCharInLine = relevantLine.length - relevantLine.trimLeft().length;
+    return new vscode.Range(lineNumber, firstCharInLine, lineNumber, lineLength);
+};
+
 // Effectively a DocumentFilter, selecting files with ".test." in them, as is the convention in Jest
 export const JestTestFileSelector: vscode.DocumentSelector = {scheme: "file", pattern: "**/*.test.*"};
 
-export class TypescriptGotoMockProvider implements vscode.CodeLensProvider {
+export class TypeScriptInsertUnmockAction implements vscode.CodeActionProvider {
+    provideCodeActions(document: vscode.TextDocument,
+                       range: vscode.Range | vscode.Selection,
+                       context: vscode.CodeActionContext,
+                       token: vscode.CancellationToken): vscode.ProviderResult<(vscode.Command | vscode.CodeAction)[]> {
+        const srcText = document.getText();
+        const matchCall = matchRequestWithoutUnmock(srcText);
+        if (!matchCall) {
+            return;
+        }
+        const relevantRange = getRangeFromTextAndMatch(srcText, matchCall);
+        if (!relevantRange.contains(range)) {
+            return;
+        }
+
+        const action = new vscode.CodeAction("Insert call to unmock", vscode.CodeActionKind.QuickFix);
+        action.command = {command: "unmock.insertUnmockToTest", title: "Insert call to unmock", arguments: [relevantRange]};
+        action.diagnostics = [
+            new vscode.Diagnostic(relevantRange,
+                                    `This test file might make real calls to remote endpoints.\n
+                                    You can use unmock to intercept these and get semantically correct mocked responses instead.`,
+                                    vscode.DiagnosticSeverity.Information)
+        ];
+        return [action];
+    }
+}
+
+export class TypescriptInsertUnmockCodeLens implements vscode.CodeLensProvider {
     onDidChangeCodeLenses?: vscode.Event<void> | undefined;
     provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens[]> {
         const srcText = document.getText();
-        // Remove comments (see https://gist.github.com/DesignByOnyx/05c2241affc9dc498379e0d819c4d756)
-        const srcTextWithoutComments = srcText.replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, "");
-        // Really rough sketch - look for the following as method calls
-        if (/[\w_]+\.(?:request|get|delete|head|options|post|put|patch)\(/.test(srcTextWithoutComments) &&
-            /axios|superagent|request|fetch|supertest/.test(srcTextWithoutComments) &&  // And one of these libraries has to be used
-            !/unmock\(/.test(srcTextWithoutComments)) {  // And there was no call to Unmock
-                // get line number and position -- this is unneeded if we want to show it next to the calling code
-                const matchCall = srcText.match(/[\w_]+\.(?:request|get|delete|head|options|post|put|patch)\(/);
-                if (!matchCall) {
-                    return;  // Shouldn't reach here, as we found the pattern in the text without comments...
-                }
-                let lineNumber = srcText.substr(0, matchCall.index).split("\n").length;
-                lineNumber = lineNumber > 0 ? lineNumber - 1 : lineNumber;  // Show it above where needed if possible
-                const lineLength = srcText.split("\n")[lineNumber].length;
-                // Do we want to show it at the top or around the calling code?
-                // const firstInDocument = new vscode.Position(0, 0); // Place to suggest the fix
-                const suggestionRange = new vscode.Range(lineNumber, 0, lineNumber, lineLength);
-                return [
-                    new vscode.CodeLens(suggestionRange, {
-                        command: "unmock.insertUnmockToTest",
-                        title: "Insert call to unmock",
-                        tooltip: "This test file might make actual calls to remote endpoints. You can use unmock to intercept these and get semantically correct responses instead!",
-                    })
-                ];
+        const matchCall = matchRequestWithoutUnmock(srcText);
+        if (!matchCall) {
+            return;
         }
-        return;
-    }
-    resolveCodeLens(codeLens: vscode.CodeLens, token: vscode.CancellationToken): vscode.ProviderResult<vscode.CodeLens> {
-        throw new Error("Method not implemented.");
+        const relevantRange = getRangeFromTextAndMatch(srcText, matchCall);
+        return [
+            new vscode.CodeLens(relevantRange, {
+                command: "unmock.insertUnmockToTest",
+                title: "Insert call to unmock",
+                arguments: [relevantRange]
+            })
+        ];
     }
 }

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,49 +1,5 @@
 import * as vscode from "vscode";
-import { print } from "util";
-
-const removeCommentsFromSourceText = (srcText: string) => {
-    return srcText.replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, "");
-};
-
-const matchRequestWithoutUnmock = (srcText: string) => {
-    // Remove comments (see https://gist.github.com/DesignByOnyx/05c2241affc9dc498379e0d819c4d756)
-    const srcTextWithoutComments = removeCommentsFromSourceText(srcText);
-    // Really rough sketch - look for the following as method calls
-    if (/[\w_]+\.(?:request|get|delete|head|options|post|put|patch)\(/.test(srcTextWithoutComments) &&
-        /axios|superagent|request|fetch|supertest/.test(srcTextWithoutComments) &&  // And one of these libraries has to be used
-        !/unmock\(/.test(srcTextWithoutComments)) {  // And there was no call to Unmock
-            return srcText.match(/[\w_]+\.(?:request|get|delete|head|options|post|put|patch)\(/);
-    }
-    return;
-};
-
-const getRangeFromTextAndMatch = (srcText: string, matchCall: RegExpMatchArray) => {
-    const lineNumber = srcText.substr(0, matchCall.index).split("\n").length - 1;  // -1 for zero-based
-    const relevantLine = srcText.split("\n")[lineNumber];
-    const lineLength = relevantLine.length;
-    const firstCharInLine = relevantLine.length - relevantLine.trimLeft().length;
-    return new vscode.Range(lineNumber, firstCharInLine, lineNumber, lineLength);
-};
-
-const findLastImport = (srcText: string) => {
-    const defaultPosition = new vscode.Position(0, 0);
-    // Get last "import" in commentless code
-    const srcTextWithoutComments = removeCommentsFromSourceText(srcText);
-    // Match for ^import
-    const match = srcTextWithoutComments.match(/^import [^;]+;/gm);
-    if (match === null) {
-        // return default answer?
-        return defaultPosition;
-    }
-    const lastMatch = match.pop();
-    if (lastMatch === undefined) {
-        // return default answer?
-        return defaultPosition;
-    }
-    // find location of lastMatch...
-    const flatIndexOf = srcText.lastIndexOf(lastMatch);
-    return new vscode.Position(srcText.substr(0, flatIndexOf).split("\n").length - 1, 0);
-};
+import { IInsertUnmockAction } from "./interfaces";
 
 // Effectively a DocumentFilter, selecting files with ".test." in them, as is the convention in Jest
 export const JestTestFileSelector: vscode.DocumentSelector = {scheme: "file", pattern: "**/*.test.*"};
@@ -64,17 +20,18 @@ export class TypeScriptInsertUnmockAction implements vscode.CodeActionProvider {
         }
 
         const action = new vscode.CodeAction("Insert call to unmock", vscode.CodeActionKind.QuickFix);
+        const insertAction: IInsertUnmockAction = {lastImportLocation: findLastImport(srcText), addImport: true};
         action.command = {
             command: "unmock.insertUnmockToTest",
             title: "Insert call to unmock",
-            arguments: [{lastImportLocation: findLastImport(srcText), relevantRange}]
+            arguments: [insertAction]
         };
-        action.diagnostics = [
-            new vscode.Diagnostic(relevantRange,
-                                    `This test file might make real calls to remote endpoints.\n
-                                    You can use unmock to intercept these and get semantically correct mocked responses instead.`,
-                                    vscode.DiagnosticSeverity.Information)
-        ];
+        const diagnostic = new vscode.Diagnostic(relevantRange,
+                                                 "This test file might make real calls to remote endpoints.\n" +
+                                                 "You can use unmock to intercept these and get semantically " +
+                                                 "correct mocked responses instead.",
+                                                 vscode.DiagnosticSeverity.Information);
+        action.diagnostics = [diagnostic];
         return [action];
     }
 }
@@ -89,12 +46,58 @@ export class TypescriptInsertUnmockCodeLens implements vscode.CodeLensProvider {
             return;
         }
         const relevantRange = getRangeFromTextAndMatch(srcText, matchCall);
+        const insertAction: IInsertUnmockAction = {lastImportLocation: findLastImport(srcText), addImport: true};
         return [
             new vscode.CodeLens(relevantRange, {
                 command: "unmock.insertUnmockToTest",
                 title: "Insert call to unmock",
-                arguments: [{lastImportLocation: findLastImport(srcText), relevantRange}]
+                arguments: [insertAction]
             })
         ];
     }
+}
+
+// The following are defined as functions and not using the const and arrow style, so we can call them
+// from anywhere in the file while keeping the exported objects at the top of this file :)
+
+function removeCommentsFromSourceText(srcText: string) {
+    return srcText.replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, "");
+}
+
+function matchRequestWithoutUnmock(srcText: string) {
+    // Remove comments (see https://gist.github.com/DesignByOnyx/05c2241affc9dc498379e0d819c4d756)
+    const srcTextWithoutComments = removeCommentsFromSourceText(srcText);
+    // Really rough sketch - look for the following as method calls
+    if (/[\w_]+\.(?:request|get|delete|head|options|post|put|patch)\(/.test(srcTextWithoutComments) &&
+        /axios|superagent|request|fetch|supertest/.test(srcTextWithoutComments) &&  // And one of these libraries has to be used
+        !/unmock\(/.test(srcTextWithoutComments)) {  // And there was no call to Unmock
+            return srcText.match(/[\w_]+\.(?:request|get|delete|head|options|post|put|patch)\(/);
+    }
+    return;
+}
+
+function getRangeFromTextAndMatch(srcText: string, matchCall: RegExpMatchArray) {
+    const lineNumber = srcText.substr(0, matchCall.index).split("\n").length - 1;  // -1 for zero-based
+    const relevantLine = srcText.split("\n")[lineNumber];
+    const lineLength = relevantLine.length;
+    const firstCharInLine = relevantLine.length - relevantLine.trimLeft().length;
+    return new vscode.Range(lineNumber, firstCharInLine, lineNumber, lineLength);
+}
+
+function findLastImport(srcText: string) {
+    const defaultPosition = new vscode.Position(0, 0);
+    // Get last "import" in commentless code
+    const srcTextWithoutComments = removeCommentsFromSourceText(srcText);
+    // Match for ^import
+    const match = srcTextWithoutComments.match(/^import [^;]+;/gm);
+    if (match === null) {
+        return defaultPosition;
+    }
+    const lastMatch = match.pop();
+    if (lastMatch === undefined) {
+        return defaultPosition;
+    }
+    // find location of lastMatch...
+    const flatIndexOf = srcText.lastIndexOf(lastMatch);
+    return new vscode.Position(srcText.substr(0, flatIndexOf).split("\n").length - 1, 0);
 }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -4,6 +4,7 @@
 //
 
 // The module 'assert' provides assertion methods from node
+import axios from "axios";
 import * as assert from 'assert';
 
 // You can import and use all API from the 'vscode' module
@@ -18,5 +19,6 @@ suite("Extension Tests", function () {
     test("Something 1", function() {
         assert.equal(-1, [1, 2, 3].indexOf(5));
         assert.equal(-1, [1, 2, 3].indexOf(0));
+        axios.get("https://www.example.com");
     });
 });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -22,3 +22,5 @@ suite("Extension Tests", function () {
         axios.get("https://www.example.com");
     });
 });
+
+axios.put("/lol");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,20 @@ import axios from "axios";
 import * as vscode from "vscode";
 import * as fs from "fs";
 
+export function getImportStatement(lang: string): string | undefined {
+    lang = lang.toLowerCase();
+    if (lang === "typescript" || lang === "javascript") {
+        return "import { unmock, kcomnu } from \"unmock\"";
+    }
+}
+
+export function getTestCalls(lang: string): string | undefined {
+    lang = lang.toLowerCase();
+    if (lang === "typescript" || lang === "javascript") {
+        return "beforeEach(async () => await unmock());\nafterEach(() => kcomnu());";
+    }
+}
+
 export async function getAccessToken() {
     const refreshToken = getRefreshToken();
     if (refreshToken === undefined) {


### PR DESCRIPTION
Addresses [UN-56] and #2.
Currently aimed at using typescript/javascript, but made to be easily extendable to other languages.
Assumptions for the JS way of things (all points must be met)
1. Only applies to files with a `.ts, .js, .tsx, .jsx` files with: `.test.` in their filename **or** located under `/test/` **or** located under `/tests/`.
2. If there iss a call to one of the common HTTP methods: `request|get|delete|head|options|post|put|patch`.
3. If one of the common JS http request libraries are used: `axios|superagent|request|fetch|supertest`
4. If a call to `unmock` has not been made.

Then:
1. Shows a CodeLens suggestion for the **first** match in the file (so as to not spam the entire code and mess up with vertical space in the IDE):
![image](https://user-images.githubusercontent.com/12184618/55226778-7c55b900-521e-11e9-9c15-8eb15f1a5e6c.png)
2. Shows a lightbulb (`Information`) suggestion when the user is on the relevant call:
![image](https://user-images.githubusercontent.com/12184618/55227013-0867e080-521f-11e9-90d9-7a986dcdf8fa.png)
3. Shows a tooltip over the matching URLs with a small explanation and a link to action:
![image](https://user-images.githubusercontent.com/12184618/55227051-233a5500-521f-11e9-9255-7f3885951d06.png)


[UN-56]: https://meeshkan.atlassian.net/browse/UN-56